### PR TITLE
Support Gnome 42 and update docs to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Make sure you're using static workspaces **(required)**
 dconf write /org/gnome/shell/overrides/dynamic-workspaces false
 ```
 
+or for Gnome 42:
+
+```
+dconf write /org/gnome/mutter/dynamic-workspaces false
+```
+
 ### Suggested setup
 
 Here's some quick tips for getting an i3-like experience in Gnome.

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Workspace indication with an i3/polybar style.",
   "uuid": "simply.workspaces@andyrichardson.dev",
   "version": 1,
-  "shell-version": ["40", "41"],
+  "shell-version": ["40", "41", "42"],
   "url": "https://github.com/andyrichardson/simply-workspaces"
 }


### PR DESCRIPTION
Thanks for the super useful extension!

I found it works just fine on Gnome 42 but the dconf key for disabling dynamic workspaces has moved. 